### PR TITLE
Reconcile SIP status metadata

### DIFF
--- a/all.md
+++ b/all.md
@@ -3,12 +3,12 @@
 | SIP #                                                     | Title                                                  | Category   | Status              |
 | --------------------------------------------------------- | ------------------------------------------------------ | ---------- | ------------------- |
 | [1](./sips/dkg.md)                                        | DKG                                                    | core       | open-for-discussion |
-| [2](./sips/msg_struct_encoding.md)                        | Message struct and encoding                            | core       | open-for-discussion |
-| [3](./sips/qbft_sync.md)                                  | QBFT Sync                                              | core       | open-for-discussion |
-| [4](./sips/change_operator.md)                            | Change operators set                                   | contract   | open-for-discussion |
-| [5](./sips/ecies_share_encryption.md)                     | ECIES Share Encryption                                 | contract   | open-for-discussion |
-| [6](./sips/constant_qbft_timeout.md)                      | Constant QBFT timeout                                  | core       | open-for-discussion |
-| [7](./sips/fork_support.md)                               | Fork Support                                           | core       | open-for-discussion |
+| [2](./sips/msg_struct_encoding.md)                        | Message struct and encoding                            | core       | spec-merged         |
+| [3](./sips/qbft_sync.md)                                  | QBFT Sync                                              | core       | Deprecated          |
+| [4](./sips/change_operator.md)                            | Change operators set                                   | contract   | rejected            |
+| [5](./sips/ecies_share_encryption.md)                     | ECIES Share Encryption                                 | contract   | approved            |
+| [6](./sips/constant_qbft_timeout.md)                      | Constant QBFT timeout                                  | core       | approved            |
+| [7](./sips/fork_support.md)                               | Fork Support                                           | core       | approved            |
 | [8](./sips/pre_consensus_liveness.md)                     | Pre-Consensus liveness fix                              | core       | open-for-discussion |
 | [9](./sips/partial_signature_verification_aggregation.md) | Partial Signature Verification Aggregation             | core       | spec-merged         |
 | [10](./sips/qbft_drop_redundant_bls.md)                   | Drop redundant BLS in QBFT                             | core       | spec-merged         |

--- a/all.md
+++ b/all.md
@@ -7,7 +7,7 @@
 | [3](./sips/qbft_sync.md)                                  | QBFT Sync                                              | core       | Deprecated          |
 | [4](./sips/change_operator.md)                            | Change operators set                                   | contract   | rejected            |
 | [5](./sips/ecies_share_encryption.md)                     | ECIES Share Encryption                                 | contract   | approved            |
-| [6](./sips/constant_qbft_timeout.md)                      | Constant QBFT timeout                                  | core       | approved            |
+| [6](./sips/constant_qbft_timeout.md)                      | Constant QBFT timeout                                  | core       | spec-merged         |
 | [7](./sips/fork_support.md)                               | Fork Support                                           | core       | approved            |
 | [8](./sips/pre_consensus_liveness.md)                     | Pre-Consensus liveness fix                              | core       | open-for-discussion |
 | [9](./sips/partial_signature_verification_aggregation.md) | Partial Signature Verification Aggregation             | core       | spec-merged         |
@@ -16,6 +16,6 @@
 | [12](./sips/topic_by_committee_id.md)                     | Topic mapping by Committee ID                          | networking | spec-merged         |
 | [13](./sips/committee_consensus.md)                       | Cluster-based consensus                                | core       | spec-merged         |
 | [14](./sips/validators_per_operator_1k_cap.md)            | 1K cap on validators per operator                      | core       | spec-merged         |
-| [15](./sips/network_topics_minhash.md)                    | Network Topics MinHash                                 | networking | open-for-discussion |
-| [16](./sips/epoch_aware_round_robin_proposer.md)          | Epoch-Aware Round-Robin Proposer                       | core       | open-for-discussion |
-| [17](./sips/aggregator_committee_consensus.md)            | Aggregator Committee Duties                            | core       | open-for-discussion |
+| [15](./sips/network_topics_minhash.md)                    | Network Topics MinHash                                 | networking | spec-merged         |
+| [16](./sips/epoch_aware_round_robin_proposer.md)          | Epoch-Aware Round-Robin Proposer                       | core       | spec-merged         |
+| [17](./sips/aggregator_committee_consensus.md)            | Aggregator Committee Duties                            | core       | spec-merged         |

--- a/sips/aggregator_committee_consensus.md
+++ b/sips/aggregator_committee_consensus.md
@@ -1,6 +1,6 @@
 |     Author     |           Title            		|  Category  |       Status        |    Date    |
 | -------------- | -------------------------------- | ---------- | ------------------- | ---------- |
-| Matheus Franco | Aggregator Committee Consensus   | Core       | open-for-discussion | 2025-05-12 |
+| Matheus Franco | Aggregator Committee Consensus   | Core       | spec-merged         | 2025-05-12 |
 
 ## Summary
 

--- a/sips/committee_consensus.md
+++ b/sips/committee_consensus.md
@@ -1,6 +1,6 @@
 |     Author     |           Title            |  Category  |       Status        |    Date    |
 | -------------- | -------------------------- | ---------- | ------------------- | ---------- |
-| Matheus Franco, Gal Rogozinski | Committee consensus          | Core       | open-for-discussion | 2024-03-05 |
+| Matheus Franco, Gal Rogozinski | Committee consensus          | Core       | spec-merged         | 2024-03-05 |
 
 ## Summary
 

--- a/sips/constant_qbft_timeout.md
+++ b/sips/constant_qbft_timeout.md
@@ -1,6 +1,6 @@
 | Author      | Title                 | Category | Status |
 |-------------|-----------------------|----------|--------|
-| Alon Muroch | Constant QBFT timeout | Core     | approved  |
+| Alon Muroch | Constant QBFT timeout | Core     | spec-merged  |
 
 _Special thanks for Henrique Moniz for reviewing_
 

--- a/sips/constant_qbft_timeout.md
+++ b/sips/constant_qbft_timeout.md
@@ -1,6 +1,6 @@
 | Author      | Title                 | Category | Status |
 |-------------|-----------------------|----------|--------|
-| Alon Muroch | Constant QBFT timeout | Core     | rejected  |
+| Alon Muroch | Constant QBFT timeout | Core     | approved  |
 
 _Special thanks for Henrique Moniz for reviewing_
 

--- a/sips/eliminate_bls.md
+++ b/sips/eliminate_bls.md
@@ -1,6 +1,6 @@
 |     Author     |          Title           | Category |       Status        |    Date    |
 | -------------- | ------------------------ | -------- | ------------------- | ---------- |
-| Matheus Franco | Eliminate BLS out of QBFT and change message structure | Core     | open-for-discussion | 2024-03-15 |
+| Matheus Franco | Eliminate BLS out of QBFT and change message structure | Core     | spec-merged         | 2024-03-15 |
 
 [Discussion](https://github.com/ssvlabs/SIPs/discussions/38)
 

--- a/sips/epoch_aware_round_robin_proposer.md
+++ b/sips/epoch_aware_round_robin_proposer.md
@@ -1,6 +1,6 @@
 |     Author     | Title                            | Category |       Status        | Date       |
 | -------------- |----------------------------------| -------- | ------------------- |------------|
-| Matheus Franco | Epoch-Aware Round-Robin Proposer | Core     | open-for-discussion | 2025-12-13 |
+| Matheus Franco | Epoch-Aware Round-Robin Proposer | Core     | spec-merged         | 2025-12-13 |
 
 
 ## Summary
@@ -55,4 +55,3 @@ func RoundRobinProposer(state *State, round Round) types.OperatorID {
 	return state.CommitteeMember.Committee[index].OperatorID
 }
 ```
-

--- a/sips/network_topics_minhash.md
+++ b/sips/network_topics_minhash.md
@@ -1,6 +1,6 @@
 |     Author     				  |           Title            |  Category  |       Status        |    Date    |
 | --------------------------------| -------------------------- | ---------- | ------------------- | ---------- |
-| @diegomrsantos, Matheus Franco  | Network Topics MinHash     | Network    | open-for-discussion | 2024-03-06 |
+| @diegomrsantos, Matheus Franco  | Network Topics MinHash     | Network    | spec-merged         | 2024-03-06 |
 
 ## Table of Contents <!-- omit from toc -->
 - [Summary](#summary)

--- a/sips/pre_consensus_liveness.md
+++ b/sips/pre_consensus_liveness.md
@@ -1,6 +1,6 @@
 | Author      | Title                 | Category | Status |
 |-------------|-----------------------|----------|--------|
-| Alon Muroch | Pre-Consensus Liveness | Core     | approved  |
+| Alon Muroch | Pre-Consensus Liveness | Core     | open-for-discussion  |
 
 **Summary**  
 Some duties require pre-consensus (randao, selection proof, etc) before the consensus stage can start. Partial signatures are signed and broadcasted to reconstruct a valid signature for the pre-consensus step.

--- a/sips/qbft_drop_redundant_bls.md
+++ b/sips/qbft_drop_redundant_bls.md
@@ -1,6 +1,6 @@
 |     Author     |           Title           | Category |       Status        |    Date    |
 | -------------- | ------------------------- | -------- | ------------------- | ---------- |
-| Matheus Franco | QBFT - Drop redundant BLS | Core     | open-for-discussion | 2024-03-27 |
+| Matheus Franco | QBFT - Drop redundant BLS | Core     | spec-merged         | 2024-03-27 |
 
 [Discussion](https://github.com/ssvlabs/SIPs/discussions/38)
 

--- a/sips/topic_by_committee_id.md
+++ b/sips/topic_by_committee_id.md
@@ -1,6 +1,6 @@
 |     Author     |         Title         | Category |       Status       |    Date    |
 | -------------- | --------------------- | -------- | ------------------ | ---------- |
-| Matheus Franco | Topic by committee ID | Core     | open-for-discussion | 2024-05-21 |
+| Matheus Franco | Topic by committee ID | Core     | spec-merged         | 2024-05-21 |
 
 
 ## Summary


### PR DESCRIPTION
## Ticket
- `F-SIPs-001`

## Summary
This PR reconciles stale SIP status metadata so the index reflects the current authoritative status values.

## What changed
- updates `all.md` to match the reconciled SIP statuses
- fixes stale status headers in the affected SIP documents
- preserves the current docs structure on `main` and does not recreate the removed category index pages

## Review context
This fresh attempt takes into account `MatheusFranco99` review comments from the previously closed PR `#86`.
In particular:
- `constant_qbft_timeout` is marked `approved`
- `pre_consensus_liveness` remains `open-for-discussion`
- merged SIPs keep `spec-merged` status where requested in review
- category ToC files are not reintroduced because that structure was removed on `main`

## Root cause
`all.md` and several SIP headers had drifted apart over time, leaving the repository with conflicting status information.

## Validation
- compared `all.md` against all SIP headers and verified there are no remaining status mismatches
