### PR TITLE
fix(Date field) - backfill Date field for SIPs based on git commit history

### DIFF
--- a/all.md
+++ b/all.md
@@ -1,21 +1,21 @@
 ## All SIPS
 
-| SIP #                                                     | Title                                                  | Category   | Status              |
-| --------------------------------------------------------- | ------------------------------------------------------ | ---------- | ------------------- |
-| [1](./sips/dkg.md)                                        | DKG                                                    | core       | open-for-discussion |
-| [2](./sips/msg_struct_encoding.md)                        | Message struct and encoding                            | core       | open-for-discussion |
-| [3](./sips/qbft_sync.md)                                  | QBFT Sync                                              | core       | open-for-discussion |
-| [4](./sips/change_operator.md)                            | Change operators set                                   | contract   | open-for-discussion |
-| [5](./sips/ecies_share_encryption.md)                     | ECIES Share Encryption                                 | contract   | open-for-discussion |
-| [6](./sips/constant_qbft_timeout.md)                      | Constant QBFT timeout                                  | core       | open-for-discussion |
-| [7](./sips/fork_support.md)                               | Fork Support                                           | core       | open-for-discussion |
-| [8](./sips/pre_consensus_liveness.md)                     | Pre-Consensus liveness fix                              | core       | open-for-discussion |
-| [9](./sips/partial_signature_verification_aggregation.md) | Partial Signature Verification Aggregation             | core       | spec-merged         |
-| [10](./sips/qbft_drop_redundant_bls.md)                   | Drop redundant BLS in QBFT                             | core       | spec-merged         |
-| [11](./sips/eliminate_bls.md)                             | Eliminate BLS out of QBFT and change message structure | core       | spec-merged         |
-| [12](./sips/topic_by_committee_id.md)                     | Topic mapping by Committee ID                          | networking | spec-merged         |
-| [13](./sips/committee_consensus.md)                       | Cluster-based consensus                                | core       | spec-merged         |
-| [14](./sips/validators_per_operator_1k_cap.md)            | 1K cap on validators per operator                      | core       | spec-merged         |
-| [15](./sips/network_topics_minhash.md)                    | Network Topics MinHash                                 | networking | open-for-discussion |
-| [16](./sips/epoch_aware_round_robin_proposer.md)          | Epoch-Aware Round-Robin Proposer                       | core       | open-for-discussion |
-| [17](./sips/aggregator_committee_consensus.md)            | Aggregator Committee Duties                            | core       | open-for-discussion |
+| SIP #                                                     | Title                                                  | Category   | Status              | Date       |
+| --------------------------------------------------------- | ------------------------------------------------------ | ---------- | ------------------- | ---------- |
+| [1](./sips/dkg.md)                                        | DKG                                                    | core       | open-for-discussion | 2022-06-27 |
+| [2](./sips/msg_struct_encoding.md)                        | Message struct and encoding                            | core       | open-for-discussion | 2022-07-26 |
+| [3](./sips/qbft_sync.md)                                  | QBFT Sync                                              | core       | open-for-discussion | 2022-09-04 |
+| [4](./sips/change_operator.md)                            | Change operators set                                   | contract   | open-for-discussion | 2022-09-04 |
+| [5](./sips/ecies_share_encryption.md)                     | ECIES Share Encryption                                 | contract   | open-for-discussion | 2022-11-09 |
+| [6](./sips/constant_qbft_timeout.md)                      | Constant QBFT timeout                                  | core       | open-for-discussion | 2022-11-19 |
+| [7](./sips/fork_support.md)                               | Fork Support                                           | core       | open-for-discussion | 2022-12-12 |
+| [8](./sips/pre_consensus_liveness.md)                     | Pre-Consensus liveness fix                             | core       | open-for-discussion | 2023-02-07 |
+| [9](./sips/partial_signature_verification_aggregation.md) | Partial Signature Verification Aggregation             | core       | spec-merged         | 2024-03-19 |
+| [10](./sips/qbft_drop_redundant_bls.md)                   | Drop redundant BLS in QBFT                             | core       | spec-merged         | 2024-03-27 |
+| [11](./sips/eliminate_bls.md)                             | Eliminate BLS out of QBFT and change message structure | core       | spec-merged         | 2024-03-15 |
+| [12](./sips/topic_by_committee_id.md)                     | Topic mapping by Committee ID                          | networking | spec-merged         | 2024-05-21 |
+| [13](./sips/committee_consensus.md)                       | Cluster-based consensus                                | core       | spec-merged         | 2024-03-05 |
+| [14](./sips/validators_per_operator_1k_cap.md)            | 1K cap on validators per operator                      | core       | spec-merged         | 2024-11-28 |
+| [15](./sips/network_topics_minhash.md)                    | Network Topics MinHash                                 | networking | open-for-discussion | 2024-03-06 |
+| [16](./sips/epoch_aware_round_robin_proposer.md)          | Epoch-Aware Round-Robin Proposer                       | core       | open-for-discussion | 2025-12-13 |
+| [17](./sips/aggregator_committee_consensus.md)            | Aggregator Committee Duties                            | core       | open-for-discussion | 2025-05-12 |

--- a/sips/change_operator.md
+++ b/sips/change_operator.md
@@ -1,6 +1,6 @@
-| Author      | Title                   | Category | Status   |
-|-------------|-------------------------|----------|----------|
-| Alon Muroch | Change operators set | Core     | rejected |
+| Author      | Title                | Category | Status   | Date       |
+|-------------|----------------------|----------|----------|------------|
+| Alon Muroch | Change operators set | Core     | rejected | 2022-09-04 |
 
 [Discussion] (https://github.com/ssvlabs/SIPs/discussions/14)
 

--- a/sips/constant_qbft_timeout.md
+++ b/sips/constant_qbft_timeout.md
@@ -1,6 +1,6 @@
-| Author      | Title                 | Category | Status |
-|-------------|-----------------------|----------|--------|
-| Alon Muroch | Constant QBFT timeout | Core     | rejected  |
+| Author      | Title                 | Category | Status   | Date       |
+|-------------|-----------------------|----------|----------|------------|
+| Alon Muroch | Constant QBFT timeout | Core     | rejected | 2022-11-19 |
 
 _Special thanks for Henrique Moniz for reviewing_
 

--- a/sips/dkg.md
+++ b/sips/dkg.md
@@ -1,6 +1,6 @@
-| Author      | Title                          | Category | Status |
-|-------------|--------------------------------|----------|--------|
-| Alon Muroch | Generalized DKG support in SSV | Core     | open-for-discussion  |
+| Author      | Title                          | Category | Status              | Date       |
+|-------------|--------------------------------|----------|---------------------|------------|
+| Alon Muroch | Generalized DKG support in SSV | Core     | open-for-discussion | 2022-06-27 |
 
 [Discussion] (https://github.com/ssvlabs/SIPs/discussions/7)
 

--- a/sips/ecies_share_encryption.md
+++ b/sips/ecies_share_encryption.md
@@ -1,6 +1,6 @@
-| Author      | Title                  | Category | Status |
-|-------------|------------------------|----------|--------|
-| Alon Muroch | ECIES Share Encryption | Core     | approved  |
+| Author      | Title                  | Category | Status   | Date       |
+|-------------|------------------------|----------|----------|------------|
+| Alon Muroch | ECIES Share Encryption | Core     | approved | 2022-11-09 |
 
 [Discussion](https://github.com/ssvlabs/SIPs/discussions/19)
 

--- a/sips/fork_support.md
+++ b/sips/fork_support.md
@@ -1,6 +1,6 @@
-| Author      | Title        | Category | Status |
-|-------------|--------------|----------|--------|
-| Alon Muroch & Matheus Franco | Fork Support | Core     | approved  |
+| Author                       | Title        | Category | Status   | Date       |
+|------------------------------|--------------|----------|----------|------------|
+| Alon Muroch & Matheus Franco | Fork Support | Core     | approved | 2022-12-12 |
 
 **Summary**  
 Describes how to support forks in the SSV network.

--- a/sips/instance_decided_enforcement.md
+++ b/sips/instance_decided_enforcement.md
@@ -1,6 +1,6 @@
-| Author      | Title                        | Category | Status |
-|-------------|------------------------------|----------|--------|
-| Alon Muroch | Instance Decided Enforcement | Core     | open-for-discussion  |
+| Author      | Title                        | Category | Status              | Date       |
+|-------------|------------------------------|----------|---------------------|------------|
+| Alon Muroch | Instance Decided Enforcement | Core     | open-for-discussion | 2023-09-14 |
 
 **Summary**
 

--- a/sips/msg_struct_encoding.md
+++ b/sips/msg_struct_encoding.md
@@ -1,6 +1,6 @@
-| Author      | Title                          | Category | Status   |
-|-------------|--------------------------------|----------|----------|
-| Alon Muroch | Messages structure and encoding | Core     | spec-merged |
+| Author      | Title                           | Category | Status      | Date       |
+|-------------|---------------------------------|----------|-------------|------------|
+| Alon Muroch | Messages structure and encoding | Core     | spec-merged | 2022-07-26 |
 
 [Discussion](https://github.com/ssvlabs/SIPs/discussions/8)
 

--- a/sips/pre_consensus_liveness.md
+++ b/sips/pre_consensus_liveness.md
@@ -1,6 +1,6 @@
-| Author      | Title                 | Category | Status |
-|-------------|-----------------------|----------|--------|
-| Alon Muroch | Pre-Consensus Liveness | Core     | approved  |
+| Author      | Title                  | Category | Status   | Date       |
+|-------------|------------------------|----------|----------|------------|
+| Alon Muroch | Pre-Consensus Liveness | Core     | approved | 2023-02-07 |
 
 **Summary**  
 Some duties require pre-consensus (randao, selection proof, etc) before the consensus stage can start. Partial signatures are signed and broadcasted to reconstruct a valid signature for the pre-consensus step.

--- a/sips/qbft_sync.md
+++ b/sips/qbft_sync.md
@@ -1,7 +1,7 @@
 
-| Author      | Title     | Category | Status |
-|-------------|-----------|----------|--------|
-| Alon Muroch | QBFT Sync | Core     | Deprecated  |
+| Author      | Title     | Category | Status     | Date       |
+|-------------|-----------|----------|------------|------------|
+| Alon Muroch | QBFT Sync | Core     | Deprecated | 2022-09-04 |
 
 [Discussion] (https://github.com/ssvlabs/SIPs/discussions/12)
 

--- a/sips/sip0.md
+++ b/sips/sip0.md
@@ -1,6 +1,6 @@
-| Author      | Title          | Category | Status   |
-|-------------|----------------|----------|----------|
-| Alon Muroch | SIP life cycle | Core     | approved |
+| Author      | Title          | Category | Status   | Date       |
+|-------------|----------------|----------|----------|------------|
+| Alon Muroch | SIP life cycle | Core     | approved | 2022-07-25 |
 
 **Summary**  
 Describes an SIPs life cycle from being submitted all the way to being accepted, standardized and merged into the spec (if applicable)

--- a/sips/voluntary_exit.md
+++ b/sips/voluntary_exit.md
@@ -1,6 +1,6 @@
-| Author      | Title                          | Category | Status |
-|-------------|--------------------------------|----------|--------|
-| Alon Muroch | Voluntary Exit | Core     | Draft  |
+| Author      | Title          | Category | Status | Date       |
+|-------------|----------------|----------|--------|------------|
+| Alon Muroch | Voluntary Exit | Core     | Draft  | 2023-08-30 |
 
 
 **Summary**


### PR DESCRIPTION
## Summary

- Add a `Date` column to all SIP headers that were missing it (SIPs 0-8, voluntary_exit, instance_decided_enforcement)
- Backfill dates using git commit history (`git log --diff-filter=A`) for each SIP file
- Add `Date` column to the `all.md` index table with dates for all 17 SIPs

## Motivation

Only SIPs 9+ included a `Date` field in their header, even though the SIP template already defines one. Without dates on older SIPs, it was impossible to understand the chronological evolution of the protocol.

## Changes

| File | Date added |
|------|------------|
| `sips/sip0.md` | 2022-07-25 |
| `sips/dkg.md` | 2022-06-27 |
| `sips/msg_struct_encoding.md` | 2022-07-26 |
| `sips/qbft_sync.md` | 2022-09-04 |
| `sips/change_operator.md` | 2022-09-04 |
| `sips/ecies_share_encryption.md` | 2022-11-09 |
| `sips/constant_qbft_timeout.md` | 2022-11-19 |
| `sips/fork_support.md` | 2022-12-12 |
| `sips/pre_consensus_liveness.md` | 2023-02-07 |
| `sips/voluntary_exit.md` | 2023-08-30 |
| `sips/instance_decided_enforcement.md` | 2023-09-14 |
| `all.md` | All 17 SIPs |

SIPs that already had dates (9-17) were left unchanged. Dates for SIPs 9-17 in `all.md` were taken from the existing values in each SIP file.

Closes https://github.com/ssvlabs/ssv-node-board/issues/513