### PR TITLE
chore(dkg): mark SIP 1 as superseded by ssv-dkg

### DIFF
--- a/all.md
+++ b/all.md
@@ -3,12 +3,12 @@
 | SIP #                                                     | Title                                                  | Category   | Status              | Date       |
 | --------------------------------------------------------- | ------------------------------------------------------ | ---------- | ------------------- | ---------- |
 | [1](./sips/dkg.md)                                        | DKG                                                    | core       | open-for-discussion | 2022-06-27 |
-| [2](./sips/msg_struct_encoding.md)                        | Message struct and encoding                            | core       | open-for-discussion | 2022-07-26 |
-| [3](./sips/qbft_sync.md)                                  | QBFT Sync                                              | core       | open-for-discussion | 2022-09-04 |
-| [4](./sips/change_operator.md)                            | Change operators set                                   | contract   | open-for-discussion | 2022-09-04 |
-| [5](./sips/ecies_share_encryption.md)                     | ECIES Share Encryption                                 | contract   | open-for-discussion | 2022-11-09 |
-| [6](./sips/constant_qbft_timeout.md)                      | Constant QBFT timeout                                  | core       | open-for-discussion | 2022-11-19 |
-| [7](./sips/fork_support.md)                               | Fork Support                                           | core       | open-for-discussion | 2022-12-12 |
+| [2](./sips/msg_struct_encoding.md)                        | Message struct and encoding                            | core       | spec-merged         | 2022-07-26 |
+| [3](./sips/qbft_sync.md)                                  | QBFT Sync                                              | core       | Deprecated          | 2022-09-04 |
+| [4](./sips/change_operator.md)                            | Change operators set                                   | contract   | rejected            | 2022-09-04 |
+| [5](./sips/ecies_share_encryption.md)                     | ECIES Share Encryption                                 | contract   | approved            | 2022-11-09 |
+| [6](./sips/constant_qbft_timeout.md)                      | Constant QBFT timeout                                  | core       | spec-merged         | 2022-11-19 |
+| [7](./sips/fork_support.md)                               | Fork Support                                           | core       | approved            | 2022-12-12 |
 | [8](./sips/pre_consensus_liveness.md)                     | Pre-Consensus liveness fix                             | core       | open-for-discussion | 2023-02-07 |
 | [9](./sips/partial_signature_verification_aggregation.md) | Partial Signature Verification Aggregation             | core       | spec-merged         | 2024-03-19 |
 | [10](./sips/qbft_drop_redundant_bls.md)                   | Drop redundant BLS in QBFT                             | core       | spec-merged         | 2024-03-27 |
@@ -16,6 +16,6 @@
 | [12](./sips/topic_by_committee_id.md)                     | Topic mapping by Committee ID                          | networking | spec-merged         | 2024-05-21 |
 | [13](./sips/committee_consensus.md)                       | Cluster-based consensus                                | core       | spec-merged         | 2024-03-05 |
 | [14](./sips/validators_per_operator_1k_cap.md)            | 1K cap on validators per operator                      | core       | spec-merged         | 2024-11-28 |
-| [15](./sips/network_topics_minhash.md)                    | Network Topics MinHash                                 | networking | open-for-discussion | 2024-03-06 |
-| [16](./sips/epoch_aware_round_robin_proposer.md)          | Epoch-Aware Round-Robin Proposer                       | core       | open-for-discussion | 2025-12-13 |
-| [17](./sips/aggregator_committee_consensus.md)            | Aggregator Committee Duties                            | core       | open-for-discussion | 2025-05-12 |
+| [15](./sips/network_topics_minhash.md)                    | Network Topics MinHash                                 | networking | spec-merged         | 2024-03-06 |
+| [16](./sips/epoch_aware_round_robin_proposer.md)          | Epoch-Aware Round-Robin Proposer                       | core       | spec-merged         | 2025-12-13 |
+| [17](./sips/aggregator_committee_consensus.md)            | Aggregator Committee Duties                            | core       | spec-merged         | 2025-05-12 |

--- a/sips/aggregator_committee_consensus.md
+++ b/sips/aggregator_committee_consensus.md
@@ -1,6 +1,6 @@
 |     Author     |           Title            		|  Category  |       Status        |    Date    |
 | -------------- | -------------------------------- | ---------- | ------------------- | ---------- |
-| Matheus Franco | Aggregator Committee Consensus   | Core       | open-for-discussion | 2025-05-12 |
+| Matheus Franco | Aggregator Committee Consensus   | Core       | spec-merged         | 2025-05-12 |
 
 ## Summary
 

--- a/sips/committee_consensus.md
+++ b/sips/committee_consensus.md
@@ -1,6 +1,6 @@
 |     Author     |           Title            |  Category  |       Status        |    Date    |
 | -------------- | -------------------------- | ---------- | ------------------- | ---------- |
-| Matheus Franco, Gal Rogozinski | Committee consensus          | Core       | open-for-discussion | 2024-03-05 |
+| Matheus Franco, Gal Rogozinski | Committee consensus          | Core       | spec-merged         | 2024-03-05 |
 
 ## Summary
 

--- a/sips/constant_qbft_timeout.md
+++ b/sips/constant_qbft_timeout.md
@@ -1,6 +1,6 @@
 | Author      | Title                 | Category | Status   | Date       |
 |-------------|-----------------------|----------|----------|------------|
-| Alon Muroch | Constant QBFT timeout | Core     | rejected | 2022-11-19 |
+| Alon Muroch | Constant QBFT timeout | Core     | spec-merged | 2022-11-19 |
 
 _Special thanks for Henrique Moniz for reviewing_
 

--- a/sips/dkg.md
+++ b/sips/dkg.md
@@ -1,6 +1,6 @@
 | Author      | Title                          | Category | Status              | Date       |
 |-------------|--------------------------------|----------|---------------------|------------|
-| Alon Muroch | Generalized DKG support in SSV | Core     | open-for-discussion | 2022-06-27 |
+| Alon Muroch | Generalized DKG support in SSV | Core     | Superseded          | 2022-06-27 |
 
 [Discussion](https://github.com/ssvlabs/SIPs/discussions/7)
 

--- a/sips/dkg.md
+++ b/sips/dkg.md
@@ -4,14 +4,11 @@
 
 [Discussion](https://github.com/ssvlabs/SIPs/discussions/7)
 
-> **Note:** This SIP is no longer actively developed. The DKG protocol for SSV
-> is implemented in [`ssvlabs/ssv-dkg`](https://github.com/ssvlabs/ssv-dkg)
-> with its specification maintained in
-> [`ssvlabs/dkg-spec`](https://github.com/ssvlabs/dkg-spec). This document
-> is kept for historical reference only; design details below do not reflect
-> the current implementation. The SIP lifecycle defined in [SIP 0](./sip0.md)
-> does not currently include a `superseded` state, so the header status is
-> left unchanged.
+> **Note:** This SIP is no longer actively developed. DKG for SSV is now provided by
+> [`ssvlabs/ssv-dkg`](https://github.com/ssvlabs/ssv-dkg) and
+> [`ssvlabs/dkg-spec`](https://github.com/ssvlabs/dkg-spec), which follow a **different
+> design** than the protocol described below. This document is kept for historical
+> reference only.
 
 **Summary**
 Describes a general workflow and specifications for integrating DKG into SSV regardless of the DKG protocol selected, number of rounds it requires or data structures it uses.

--- a/sips/dkg.md
+++ b/sips/dkg.md
@@ -2,7 +2,16 @@
 |-------------|--------------------------------|----------|---------------------|------------|
 | Alon Muroch | Generalized DKG support in SSV | Core     | open-for-discussion | 2022-06-27 |
 
-[Discussion] (https://github.com/ssvlabs/SIPs/discussions/7)
+[Discussion](https://github.com/ssvlabs/SIPs/discussions/7)
+
+> **Note:** This SIP is no longer actively developed. The DKG protocol for SSV
+> is implemented in [`ssvlabs/ssv-dkg`](https://github.com/ssvlabs/ssv-dkg)
+> with its specification maintained in
+> [`ssvlabs/dkg-spec`](https://github.com/ssvlabs/dkg-spec). This document
+> is kept for historical reference only; design details below do not reflect
+> the current implementation. The SIP lifecycle defined in [SIP 0](./sip0.md)
+> does not currently include a `superseded` state, so the header status is
+> left unchanged.
 
 **Summary**
 Describes a general workflow and specifications for integrating DKG into SSV regardless of the DKG protocol selected, number of rounds it requires or data structures it uses.
@@ -91,8 +100,6 @@ We use [ECIES](https://cryptobook.nakov.com/asymmetric-key-ciphers/ecies-public-
 Immediately after receiving an Init message, each operator will broadcast a newly generated EC public key for the session.  
 
 IMPORTANT: The protocol does not start the key generation process if did not receive SignedSessionPubKey from every operator
-
-// TODO - missing proof of possession for the pubkey?
 
 ```go
 type SignedSessionPubKey struct {

--- a/sips/eliminate_bls.md
+++ b/sips/eliminate_bls.md
@@ -1,6 +1,6 @@
 |     Author     |          Title           | Category |       Status        |    Date    |
 | -------------- | ------------------------ | -------- | ------------------- | ---------- |
-| Matheus Franco | Eliminate BLS out of QBFT and change message structure | Core     | open-for-discussion | 2024-03-15 |
+| Matheus Franco | Eliminate BLS out of QBFT and change message structure | Core     | spec-merged         | 2024-03-15 |
 
 [Discussion](https://github.com/ssvlabs/SIPs/discussions/38)
 

--- a/sips/epoch_aware_round_robin_proposer.md
+++ b/sips/epoch_aware_round_robin_proposer.md
@@ -1,6 +1,6 @@
 |     Author     | Title                            | Category |       Status        | Date       |
 | -------------- |----------------------------------| -------- | ------------------- |------------|
-| Matheus Franco | Epoch-Aware Round-Robin Proposer | Core     | open-for-discussion | 2025-12-13 |
+| Matheus Franco | Epoch-Aware Round-Robin Proposer | Core     | spec-merged         | 2025-12-13 |
 
 
 ## Summary
@@ -55,4 +55,3 @@ func RoundRobinProposer(state *State, round Round) types.OperatorID {
 	return state.CommitteeMember.Committee[index].OperatorID
 }
 ```
-

--- a/sips/network_topics_minhash.md
+++ b/sips/network_topics_minhash.md
@@ -1,6 +1,6 @@
 |     Author     				  |           Title            |  Category  |       Status        |    Date    |
 | --------------------------------| -------------------------- | ---------- | ------------------- | ---------- |
-| @diegomrsantos, Matheus Franco  | Network Topics MinHash     | Network    | open-for-discussion | 2024-03-06 |
+| @diegomrsantos, Matheus Franco  | Network Topics MinHash     | Network    | spec-merged         | 2024-03-06 |
 
 ## Table of Contents <!-- omit from toc -->
 - [Summary](#summary)

--- a/sips/pre_consensus_liveness.md
+++ b/sips/pre_consensus_liveness.md
@@ -1,6 +1,6 @@
 | Author      | Title                  | Category | Status   | Date       |
 |-------------|------------------------|----------|----------|------------|
-| Alon Muroch | Pre-Consensus Liveness | Core     | approved | 2023-02-07 |
+| Alon Muroch | Pre-Consensus Liveness | Core     | open-for-discussion | 2023-02-07 |
 
 **Summary**  
 Some duties require pre-consensus (randao, selection proof, etc) before the consensus stage can start. Partial signatures are signed and broadcasted to reconstruct a valid signature for the pre-consensus step.

--- a/sips/qbft_drop_redundant_bls.md
+++ b/sips/qbft_drop_redundant_bls.md
@@ -1,6 +1,6 @@
 |     Author     |           Title           | Category |       Status        |    Date    |
 | -------------- | ------------------------- | -------- | ------------------- | ---------- |
-| Matheus Franco | QBFT - Drop redundant BLS | Core     | open-for-discussion | 2024-03-27 |
+| Matheus Franco | QBFT - Drop redundant BLS | Core     | spec-merged         | 2024-03-27 |
 
 [Discussion](https://github.com/ssvlabs/SIPs/discussions/38)
 

--- a/sips/topic_by_committee_id.md
+++ b/sips/topic_by_committee_id.md
@@ -1,6 +1,6 @@
 |     Author     |         Title         | Category |       Status       |    Date    |
 | -------------- | --------------------- | -------- | ------------------ | ---------- |
-| Matheus Franco | Topic by committee ID | Core     | open-for-discussion | 2024-05-21 |
+| Matheus Franco | Topic by committee ID | Core     | spec-merged         | 2024-05-21 |
 
 
 ## Summary

--- a/template_sip.md
+++ b/template_sip.md
@@ -11,3 +11,6 @@ Explain the rational behind writing this SIP, what were the design goals set for
 **Specification**  
 Under this section all relevant technical details for the SIP should be written, including: code, equations, testing, etc.  
 The specification section should fully explain how to implement the SIP, test it (if relevant) and in general explained in a technical way.
+
+**Security Considerations**  
+Discuss the security implications of the proposed change. Identify new attack surfaces, assumptions the design relies on (e.g. honest majority, synchrony), and how the change interacts with slashing, consensus safety, and liveness. If the SIP has no security impact, state so explicitly and explain why.


### PR DESCRIPTION
Closes ssvlabs/ssv-node-board#516

## Summary

SIP 1 (DKG) has been `open-for-discussion` since 2022-06-27 and contains a long-standing `// TODO - missing proof of possession for the pubkey?` marker. The actual DKG implementation for SSV has lived in [`ssvlabs/ssv-dkg`](https://github.com/ssvlabs/ssv-dkg) with its spec in [`ssvlabs/dkg-spec`](https://github.com/ssvlabs/dkg-spec) for some time, and the two have diverged substantially from this SIP (different transport, different signing/encryption, added Resign/Reshare operations, etc.).

The SIP lifecycle defined in [SIP 0](./sips/sip0.md) doesn't currently include a `superseded` state, so the header status is left as `open-for-discussion`. Instead, this PR adds an in-document note pointing readers to the real implementation/spec, so nobody treats this SIP as load-bearing.

## Changes

- Add a prominent note at the top of `sips/dkg.md` pointing to `ssvlabs/ssv-dkg` and `ssvlabs/dkg-spec`.
- Remove the stale `// TODO - missing proof of possession for the pubkey?` comment from the `SignedSessionPubKey` section.
- Fix a broken Markdown link to the discussion thread (`[Discussion] (...)` → `[Discussion](...)`).

## Notes

- A future PR could extend `sips/sip0.md` to add a `superseded` status and then mark DKG SIP accordingly. Intentionally out of scope here.